### PR TITLE
Add Redis Cache Support

### DIFF
--- a/thirdeye/thirdeye-dashboard/config/data-sources/cache-config.yml
+++ b/thirdeye/thirdeye-dashboard/config/data-sources/cache-config.yml
@@ -31,4 +31,18 @@ centralizedCacheSettings:
         trustStoreFilePath: 'trust/store/path/truststore_file' # e.g. '/etc/riddler/cacerts'
         trustStorePassword: ''
     # add your store of choice here
-
+    redis:
+      className: org.apache.pinot.thirdeye.detection.cache.RedisCacheDAO
+      config:
+        hosts:
+          - 'redis://127.0.0.1:6379'
+        authUsername: ''
+        authPassword: ''
+        idleConnectionTimeout: 10000
+        connectTimeout: 10000
+        timeout: 3000
+        retryAttempts: 3
+        retryInterval: 1500
+        pingConnectionInterval: 30000
+        keepAlive: false
+        tcpNoDelay: false

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -239,6 +239,13 @@
       <version>2.7.9</version>
     </dependency>
 
+    <!-- Redis client dependencies -->
+    <dependency>
+      <groupId>org.redisson</groupId>
+      <artifactId>redisson</artifactId>
+      <version>3.13.6</version>
+    </dependency>
+
     <!-- demo dependencies -->
     <dependency>
       <groupId>com.h2database</groupId>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
@@ -21,193 +21,200 @@ package org.apache.pinot.thirdeye.anomaly.utils;
 
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.tracking.RequestLog;
+
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.reporting.JmxReporter;
 
-
 public class ThirdeyeMetricsUtil {
-  private static final MetricsRegistry metricsRegistry = new MetricsRegistry();
-  private static final JmxReporter jmxReporter = new JmxReporter(metricsRegistry);
-  private static final RequestLog requestLog = new RequestLog(1000000);
+	private static final MetricsRegistry metricsRegistry = new MetricsRegistry();
+	private static final JmxReporter jmxReporter = new JmxReporter(metricsRegistry);
+	private static final RequestLog requestLog = new RequestLog(1000000);
 
-  static {
-    jmxReporter.start();
-  }
+	static {
+		jmxReporter.start();
+	}
 
-  private ThirdeyeMetricsUtil() {
-  }
+	private ThirdeyeMetricsUtil() {
+	}
 
-  public static final Counter taskCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "taskCounter");
+	public static final Counter taskCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "taskCounter");
 
-  public static final Counter taskSuccessCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "taskSuccessCounter");
+	public static final Counter taskSuccessCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"taskSuccessCounter");
 
-  public static final Counter taskExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "taskExceptionCounter");
+	public static final Counter taskExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"taskExceptionCounter");
 
-  public static final Counter taskDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "taskDurationCounter");
+	public static final Counter taskDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"taskDurationCounter");
 
-  public static final Gauge<Integer> taskBacklogGauge =
-      metricsRegistry.newGauge(ThirdeyeMetricsUtil.class, "taskBacklogGauge", new Gauge<Integer>() {
-        @Override
-        public Integer value() {
-          return DAORegistry.getInstance().getTaskDAO().countWaiting();
-        }
-      });
+	public static final Gauge<Integer> taskBacklogGauge = metricsRegistry.newGauge(ThirdeyeMetricsUtil.class,
+			"taskBacklogGauge", new Gauge<Integer>() {
+				@Override
+				public Integer value() {
+					return DAORegistry.getInstance().getTaskDAO().countWaiting();
+				}
+			});
 
-  public static final Counter detectionTaskCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "detectionTaskCounter");
+	public static final Counter detectionTaskCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"detectionTaskCounter");
 
-  public static final Counter detectionTaskSuccessCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "detectionTaskSuccessCounter");
+	public static final Counter detectionTaskSuccessCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"detectionTaskSuccessCounter");
 
-  public static final Counter detectionTaskExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "detectionTaskExceptionCounter");
+	public static final Counter detectionTaskExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"detectionTaskExceptionCounter");
 
-  public static final Counter dataQualityTaskCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dataQualityTaskCounter");
+	public static final Counter dataQualityTaskCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dataQualityTaskCounter");
 
-  public static final Counter dataQualityTaskSuccessCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dataQualityTaskSuccessCounter");
+	public static final Counter dataQualityTaskSuccessCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dataQualityTaskSuccessCounter");
 
-  public static final Counter dataQualityTaskExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dataQualityTaskExceptionCounter");
+	public static final Counter dataQualityTaskExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dataQualityTaskExceptionCounter");
 
-  public static final Counter alertTaskCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "alertTaskCounter");
+	public static final Counter alertTaskCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"alertTaskCounter");
 
-  public static final Counter alertTaskSuccessCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "alertTaskSuccessCounter");
+	public static final Counter alertTaskSuccessCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"alertTaskSuccessCounter");
 
-  public static final Counter alertTaskExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "alertTaskExceptionCounter");
+	public static final Counter alertTaskExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"alertTaskExceptionCounter");
 
-  public static final Counter dbCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbCallCounter");
+	public static final Counter dbCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbCallCounter");
 
-  public static final Counter dbExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbExceptionCounter");
+	public static final Counter dbExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbExceptionCounter");
 
-  public static final Counter dbReadCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbReadCallCounter");
+	public static final Counter dbReadCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbReadCallCounter");
 
-  public static final Counter dbReadByteCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbReadByteCounter");
+	public static final Counter dbReadByteCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbReadByteCounter");
 
-  public static final Counter dbReadDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbReadDurationCounter");
+	public static final Counter dbReadDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbReadDurationCounter");
 
-  public static final Counter dbWriteCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbWriteCallCounter");
+	public static final Counter dbWriteCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbWriteCallCounter");
 
-  public static final Counter dbWriteByteCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbWriteByteCounter");
+	public static final Counter dbWriteByteCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbWriteByteCounter");
 
-  public static final Counter dbWriteDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "dbWriteDurationCounter");
+	public static final Counter dbWriteDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"dbWriteDurationCounter");
 
-  public static final Counter datasourceCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "datasourceCallCounter");
+	public static final Counter datasourceCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"datasourceCallCounter");
 
-  public static final Counter datasourceDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "datasourceDurationCounter");
+	public static final Counter datasourceDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"datasourceDurationCounter");
 
-  public static final Counter datasourceExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "datasourceExceptionCounter");
+	public static final Counter datasourceExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"datasourceExceptionCounter");
 
-  public static final Counter couchbaseCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "couchbaseCallCounter");
+	public static final Counter couchbaseCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"couchbaseCallCounter");
 
-  public static final Counter couchbaseWriteCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "couchbaseWriteCounter");
+	public static final Counter couchbaseWriteCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"couchbaseWriteCounter");
 
-  public static final Counter couchbaseExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "couchbaseExceptionCounter");
+	public static final Counter couchbaseExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"couchbaseExceptionCounter");
 
-  public static final Counter pinotCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "pinotCallCounter");
+	public static final Counter redisCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"redisCallCounter");
 
-  public static final Counter pinotDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "pinotDurationCounter");
+	public static final Counter redisWriteCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"redisWriteCounter");
 
-  public static final Counter pinotExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "pinotExceptionCounter");
+	public static final Counter redisExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"redisExceptionCounter");
 
-  public static final Counter rcaPipelineCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "rcaPipelineCallCounter");
+	public static final Counter pinotCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"pinotCallCounter");
 
-  public static final Counter rcaPipelineDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "rcaPipelineDurationCounter");
+	public static final Counter pinotDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"pinotDurationCounter");
 
-  public static final Counter rcaPipelineExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "rcaPipelineExceptionCounter");
+	public static final Counter pinotExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"pinotExceptionCounter");
 
-  public static final Counter rcaFrameworkCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "rcaFrameworkCallCounter");
+	public static final Counter rcaPipelineCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"rcaPipelineCallCounter");
 
-  public static final Counter rcaFrameworkDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "rcaFrameworkDurationCounter");
+	public static final Counter rcaPipelineDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"rcaPipelineDurationCounter");
 
-  public static final Counter rcaFrameworkExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "rcaFrameworkExceptionCounter");
+	public static final Counter rcaPipelineExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"rcaPipelineExceptionCounter");
 
-  public static final Counter cubeCallCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "cubeCallCounter");
+	public static final Counter rcaFrameworkCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"rcaFrameworkCallCounter");
 
-  public static final Counter cubeDurationCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "cubeDurationCounter");
+	public static final Counter rcaFrameworkDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"rcaFrameworkDurationCounter");
 
-  public static final Counter cubeExceptionCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "cubeExceptionCounter");
+	public static final Counter rcaFrameworkExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"rcaFrameworkExceptionCounter");
 
-  public static final Counter detectionRetuneCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "detectionRetuneCounter");
+	public static final Counter cubeCallCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"cubeCallCounter");
 
-  public static final Counter triggerEventCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "triggerEventCounter");
+	public static final Counter cubeDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"cubeDurationCounter");
 
-  public static final Counter processedTriggerEventCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "processedTriggerEventCounter");
+	public static final Counter cubeExceptionCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"cubeExceptionCounter");
 
-  public static final Counter eventScheduledTaskCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "eventScheduledTaskCounter");
+	public static final Counter detectionRetuneCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"detectionRetuneCounter");
 
-  public static final Counter eventScheduledTaskFallbackCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "eventScheduledTaskFallbackCounter");
+	public static final Counter triggerEventCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"triggerEventCounter");
 
-  public static final Counter emailAlertsSucesssCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "emailAlertsSucesssCounter");
+	public static final Counter processedTriggerEventCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"processedTriggerEventCounter");
 
-  public static final Counter emailAlertsFailedCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "emailAlertsFailedCounter");
+	public static final Counter eventScheduledTaskCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"eventScheduledTaskCounter");
 
-  public static final Counter jiraAlertsSuccessCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsSuccessCounter");
+	public static final Counter eventScheduledTaskFallbackCounter = metricsRegistry
+			.newCounter(ThirdeyeMetricsUtil.class, "eventScheduledTaskFallbackCounter");
 
-  public static final Counter jiraAlertsFailedCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsFailedCounter");
+	public static final Counter emailAlertsSucesssCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"emailAlertsSucesssCounter");
 
-  public static final Counter jiraAlertsNumTicketsCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsNumTicketsCounter");
+	public static final Counter emailAlertsFailedCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"emailAlertsFailedCounter");
 
-  public static final Counter jiraAlertsNumCommentsCounter =
-      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsNumCommentsCounter");
+	public static final Counter jiraAlertsSuccessCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"jiraAlertsSuccessCounter");
 
-  public static final Counter onlineTaskCounter =
-          metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "onlineTaskCounter");
+	public static final Counter jiraAlertsFailedCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"jiraAlertsFailedCounter");
 
-  public static final Counter onlineTaskDurationCounter =
-          metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "onlineTaskDurationCounter");
+	public static final Counter jiraAlertsNumTicketsCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"jiraAlertsNumTicketsCounter");
 
-  public static MetricsRegistry getMetricsRegistry() {
-    return metricsRegistry;
-  }
+	public static final Counter jiraAlertsNumCommentsCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"jiraAlertsNumCommentsCounter");
 
-  public static RequestLog getRequestLog() {
-    return requestLog;
-  }
+	public static final Counter onlineTaskCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"onlineTaskCounter");
+
+	public static final Counter onlineTaskDurationCounter = metricsRegistry.newCounter(ThirdeyeMetricsUtil.class,
+			"onlineTaskDurationCounter");
+
+	public static MetricsRegistry getMetricsRegistry() {
+		return metricsRegistry;
+	}
+
+	public static RequestLog getRequestLog() {
+		return requestLog;
+	}
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConstants.java
@@ -38,5 +38,8 @@ public class CacheConstants {
 
   // refers to hashed metricURN which is used as the key to data for a dimension combination.
   public static final String DIMENSION_KEY = "dimensionKey";
+  
+  // for redis storage
+  public static final String DIMENSION_KEY_VALUE = "dimensionKeyValue";
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/RedisCacheDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/RedisCacheDAO.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.cache;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
+import org.redisson.Redisson;
+import org.redisson.api.RTimeSeries;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.RedisConnectionException;
+import org.redisson.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * DAO class used to fetch data from Redis.
+ */
+
+public class RedisCacheDAO implements CacheDAO {
+
+	private static final String HOSTS = "hosts";
+	private static final String AUTH_USERNAME = "authUsername";
+	private static final String AUTH_PASSWORD = "authPassword";
+	public static final String IDLE_CONNECTION_TIMEOUT = "idleConnectionTimeout";
+	public static final String CONNECT_TIMEOUT = "connectTimeout";
+	public static final String TIMEOUT = "timeout";
+	public static final String RETRY_ATTEMPTS = "retryAttempts";
+	public static final String RETRY_INTERVAL = "retryInterval";
+	public static final String PING_CONNECTION_INTERVAL = "pingConnectionInterval";
+	public static final String KEEP_ALIVE = "keepAlive";
+	public static final String TCP_NO_DELAY = "tcpNoDelay";
+
+	public static final String DEFAULT_HOST = "redis://127.0.0.1:6379";
+	public static final String DEFAULT_AUTH_USERNAME = "";
+	public static final String DEFAULT_AUTH_PASSWORD = "";
+	public static final int DEFAULT_IDLE_CONNECTION_TIMEOUT = 10000;
+	public static final int DEFAULT_CONNECT_TIMEOUT = 10000;
+	public static final int DEFAULT_TIMEOUT = 3000;
+	public static final int DEFAULT_RETRY_ATTEMPTS = 3;
+	public static final int DEFAULT_RETRY_INTERVAL = 1500;
+	public static final int DEFAULT_PING_CONNECTION_INTERVAL = 30000;
+	public static final boolean DEFAULT_KEEP_ALIVE = false;
+	public static final boolean DEFAULT_TCP_NO_DELAY = false;
+
+	// private static final String SERIALIZATION = "serialization";
+	// public static final String DEFAULT_SERIALIZATION = "json";
+	// public static final String DEFAULT_ALLOWED_TYPE = "aln,var";
+
+	private static final Logger LOG = LoggerFactory.getLogger(RedisCacheDAO.class);
+
+	private Config redissonConfig;
+	private RedissonClient redissonClient;
+	private boolean redisState;
+
+	// Eg: KEY = metricId:2:dimensionKey:3158902058
+	private static final String KEY_PREFIX = "metricId:";
+
+	public RedisCacheDAO() {
+		this.createDataStoreConnection();
+	}
+
+	/**
+	 * Initialize connection to Redis
+	 */
+	private void createDataStoreConnection() {
+		LOG.info("Starting Redis Connection......");
+		CacheDataSource dataSource = CacheConfig.getInstance().getCentralizedCacheSettings().getDataSourceConfig();
+		Map<String, Object> dataSourceconfig = dataSource.getConfig();
+		List<String> hosts = ConfigUtils.getList(dataSourceconfig.get(HOSTS));
+		redissonConfig = new Config();
+
+		// Taking only one host as of now.
+		String host = "";
+		if (hosts.size() == 0) {
+			host = DEFAULT_HOST;
+		} else {
+			host = (String) hosts.toArray()[0];
+		}
+		redissonConfig.useSingleServer().setAddress(host);
+
+		// If no username specified, default username ("") will be considered
+//		String username = (StringUtils.isNotEmpty((String) dataSourceconfig.get(AUTH_USERNAME)))
+//				? (String) dataSourceconfig.get(AUTH_USERNAME)
+//				: DEFAULT_USERNAME;
+//		redissonConfig.useSingleServer().setUsername(username);
+//
+//		// If no password specified, default password ("") will be considered
+//		String password = (StringUtils.isNotEmpty((String) dataSourceconfig.get(AUTH_PASSWORD)))
+//				? (String) dataSourceconfig.get(AUTH_PASSWORD)
+//				: DEFAULT_PASSWORD;
+//		redissonConfig.useSingleServer().setPassword(password);
+
+		int idleConnectionTimeout = ((Integer) dataSourceconfig.get(IDLE_CONNECTION_TIMEOUT) == null)
+				? DEFAULT_IDLE_CONNECTION_TIMEOUT
+				: (Integer) dataSourceconfig.get(IDLE_CONNECTION_TIMEOUT);
+		redissonConfig.useSingleServer().setIdleConnectionTimeout(idleConnectionTimeout);
+
+		int connectTimeout = ((Integer) dataSourceconfig.get(CONNECT_TIMEOUT) == null) ? DEFAULT_CONNECT_TIMEOUT
+				: (Integer) dataSourceconfig.get(CONNECT_TIMEOUT);
+		redissonConfig.useSingleServer().setConnectTimeout(connectTimeout);
+
+		int timeout = ((Integer) dataSourceconfig.get(TIMEOUT) == null) ? DEFAULT_TIMEOUT
+				: (Integer) dataSourceconfig.get(TIMEOUT);
+		redissonConfig.useSingleServer().setTimeout(timeout);
+
+		int retryAttempts = ((Integer) dataSourceconfig.get(RETRY_ATTEMPTS) == null) ? DEFAULT_RETRY_ATTEMPTS
+				: (Integer) dataSourceconfig.get(RETRY_ATTEMPTS);
+		redissonConfig.useSingleServer().setRetryAttempts(retryAttempts);
+
+		int retryInterval = ((Integer) dataSourceconfig.get(RETRY_INTERVAL) == null) ? DEFAULT_RETRY_INTERVAL
+				: (Integer) dataSourceconfig.get(RETRY_INTERVAL);
+		redissonConfig.useSingleServer().setRetryInterval(retryInterval);
+
+		int pingConnectionInterval = ((Integer) dataSourceconfig.get(PING_CONNECTION_INTERVAL) == null)
+				? DEFAULT_PING_CONNECTION_INTERVAL
+				: (Integer) dataSourceconfig.get(PING_CONNECTION_INTERVAL);
+		redissonConfig.useSingleServer().setPingConnectionInterval(pingConnectionInterval);
+
+		boolean keepAlive = ((Boolean) dataSourceconfig.get(KEEP_ALIVE) == null) ? DEFAULT_KEEP_ALIVE
+				: (Boolean) dataSourceconfig.get(KEEP_ALIVE);
+		redissonConfig.useSingleServer().setKeepAlive(keepAlive);
+
+		boolean tcpNoDelay = ((Boolean) dataSourceconfig.get(TCP_NO_DELAY) == null) ? DEFAULT_TCP_NO_DELAY
+				: (Boolean) dataSourceconfig.get(TCP_NO_DELAY);
+		redissonConfig.useSingleServer().setKeepAlive(tcpNoDelay);
+
+		// Creating Redisson Client
+		redissonClient = getRedissonClient();
+		redisState = true;
+		LOG.info("Redis Connection Successful.");
+	}
+
+	/**
+	 * Fetches time-series data from cache. Formats it into a list of
+	 * TimeSeriesDataPoints before returning. The raw results will look something
+	 * like this: { { "time": 1000, "123456": "30.0" }, { "time": 2000, "123456":
+	 * "893.0" }, { "time": 3000, "123456": "900.6" } }
+	 * 
+	 * @param request ThirdEyeCacheRequest. Wrapper for ThirdEyeRequest.
+	 * @return list of TimeSeriesDataPoint
+	 */
+
+	public ThirdEyeCacheResponse tryFetchExistingTimeSeries(ThirdEyeCacheRequest request) throws Exception {
+		long metricId = request.getMetricId();
+		String dimensionKey = request.getDimensionKey();
+		String keyVal = createKey(metricId, dimensionKey);
+		RTimeSeries<Map<String, Object>> ts = getRedissonClient().getTimeSeries(keyVal);
+		ThirdeyeMetricsUtil.redisCallCounter.inc();
+		if (ts.size() == 0) {
+			LOG.info("no redis cache found for window startTime = {} to endTime = {}", request.getStartTimeInclusive(),
+					request.getEndTimeExclusive());
+			ThirdeyeMetricsUtil.redisExceptionCounter.inc();
+			return new ThirdEyeCacheResponse(request, new ArrayList<>());
+		}
+
+		long start = request.getStartTimeInclusive();
+		long end = request.getEndTimeExclusive() - request.getRequest().getGroupByTimeGranularity().toMillis();
+
+		Collection<Map<String, Object>> cacheValues = ts.range(start, end);
+		LOG.info("reading redis cache for window startTime = {} to endTime = {}", request.getStartTimeInclusive(),
+				request.getEndTimeExclusive());
+		List<TimeSeriesDataPoint> timeSeriesRows = new ArrayList<>();
+		for (Map<String, Object> cacheValue : cacheValues) {
+			long timestamp = (long) cacheValue.get(CacheConstants.TIMESTAMP);
+			Double dataValue = (Double) cacheValue.get(CacheConstants.DIMENSION_KEY_VALUE);
+			timeSeriesRows.add(new TimeSeriesDataPoint(request.getMetricUrn(), timestamp, request.getMetricId(),
+					String.valueOf(dataValue)));
+		}
+		return new ThirdEyeCacheResponse(request, timeSeriesRows);
+	}
+
+	/**
+	 * Insert a TimeSeriesDataPoint into Redis. If a document for this data point
+	 * already exists within Redis and the data value for the metricURN already
+	 * exists in the cache, we don't do anything. An example document generated and
+	 * inserted for this might look like: { "timestamp": 123456700000 "metricId":
+	 * 123456, "61427020": "3.0", "83958352": "59.6", "98648743": "0.0" }
+	 * 
+	 * @param point data point
+	 */
+	public void insertTimeSeriesDataPoint(TimeSeriesDataPoint point) {
+		// Check if key (metricId:2:dimensionKey:3158902058) exists
+		// if so, then update - touch/ttl
+		// if not create a key and set data, ttl value
+
+		long timestamp = point.getTimestamp();
+		long metricId = point.getMetricId();
+		String dimensionKey = point.getMetricUrnHash();
+		String keyVal = createKey(metricId, dimensionKey);
+		ThirdeyeMetricsUtil.redisCallCounter.inc();
+
+		if (isActive()) {
+			int ttl = CacheConfig.getInstance().getCentralizedCacheSettings().getTTL();
+			// ts is the key in the redis store. Eg: metricId:2:dimensionKey:3158902058
+			RTimeSeries<Map<String, Object>> ts = getRedissonClient().getTimeSeries(keyVal);
+			Map<String, Object> cacheValue = ts.get(timestamp);
+			if (MapUtils.isEmpty(cacheValue)) {
+				Map<String, Object> values = new HashMap<String, Object>();
+				values.put(CacheConstants.TIMESTAMP, timestamp);
+				values.put(CacheConstants.METRIC_ID, point.getMetricId());
+				values.put(CacheConstants.DIMENSION_KEY, point.getMetricUrnHash());
+				values.put(CacheConstants.DIMENSION_KEY_VALUE, point.getDataValueAsDouble());
+				try {
+					// TimeSeries Data has timestamp and new content
+					LOG.info("Creating redis cache for Timestamp = {}", timestamp);
+					ts.add(timestamp, values, new Long(ttl), TimeUnit.SECONDS);
+				} catch (RedisConnectionException e) {
+					redisState = false;
+				}
+			} else {
+				String dKey = (String) cacheValue.get(CacheConstants.DIMENSION_KEY);
+				Double dimensionKeyVal = (Double) cacheValue.get(CacheConstants.DIMENSION_KEY_VALUE);
+				if (dKey == point.getMetricUrnHash() && dimensionKeyVal == point.getDataValueAsDouble()) {
+					return;
+				}
+				cacheValue.put(CacheConstants.DIMENSION_KEY, point.getMetricUrnHash());
+				cacheValue.put(CacheConstants.DIMENSION_KEY_VALUE, point.getDataValueAsDouble());
+				try {
+					ts.remove(timestamp); // removing old data as timeseries has no getAndset or update
+					// TimeSeries Data has timestamp and updated content
+					LOG.info("Updating redis cache for Timestamp = {}", timestamp);
+					ts.add(timestamp, cacheValue, new Long(ttl), TimeUnit.SECONDS);
+				} catch (RedisConnectionException e) {
+					redisState = false;
+				}
+			}
+			ts.touch();
+		}
+		ThirdeyeMetricsUtil.redisWriteCounter.inc();
+	}
+
+	public boolean isActive() {
+		return redisState;
+	}
+
+	private synchronized RedissonClient getRedissonClient() {
+		if (redissonClient == null) {
+			redissonClient = Redisson.create(redissonConfig);
+		}
+		return redissonClient;
+	}
+
+	public String createKey(long metricId, String dimensionKey) {
+		StringBuilder key = new StringBuilder(KEY_PREFIX);
+		key.append(metricId).append(":").append("dimensionKey").append(":").append(dimensionKey);
+		return key.toString();
+	}
+}


### PR DESCRIPTION
Update `incubator-pinot/thirdeye/thirdeye-dashboard/config/data-sources/cache-config.yml` with redis configuraiton

Update `/incubator-pinot/thirdeye/thirdeye-pinot/pom.xml` with redis client dependency

Update `/incubator-pinot/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java` with redis counters

Update `/incubator-pinot/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/CacheConstants.java` with dimensionKey constant

Add `/incubator-pinot/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/cache/RedisCacheDAO.java` with Redis Cache DAO

## Description
PR extends the existing cache support to Redis cache by updating/Adding above mentioned files.  Implementation & design are in line with Couchbase Cache DAO

## Upgrade Notes
Not Applicable

## Release Notes
- New configuration options : Redis Cache Configuration
- Now `incubator-pinot/thirdeye/thirdeye-dashboard/config/data-sources/cache-config.yml` supports redis configuration. Instead of cluster nodes, this PR addresses the single redis node. And the clusterNode can be easily added by changing the RedisDAO `reddison` client configuration.

## Pending Items
- [ ] Documentation
- [ ] Test Cases
