### PR TITLE
Druid Performance Fixes

### DIFF
--- a/docker-compose.thirdeye.yml
+++ b/docker-compose.thirdeye.yml
@@ -48,7 +48,7 @@ services:
       THIRDEYE_DATABASE: thirdeye
       MYSQL_PASSWORD: root
       DRUID_USER: admin
-      DRUID_PWD: pooghe6phee5wohVoo8eeBei
+      DRUID_PWD: admin
       APP_MODE: prod
       JMX_CONFIG: "-Xms1G -Xmx3G"
     ports:
@@ -83,7 +83,7 @@ services:
       THIRDEYE_DATABASE: thirdeye
       MYSQL_PASSWORD: root
       DRUID_USER: admin
-      DRUID_PWD: pooghe6phee5wohVoo8eeBei
+      DRUID_PWD: admin
       APP_MODE: prod
       JMX_CONFIG: "-Xms1G -Xmx3G"
     entrypoint: ["/bin/sh", "/opt/thirdeye/bin/entrypoint_dev.sh", "backend"]

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -372,7 +372,7 @@ public class SqlUtils {
       return String.format(" %s = %d", getToUnixTimeClause(timeFormat, timeField, sourceName), startUnits);
     }
     // This is an explicit DRUID RZP Hack
-    if (sourceName.equals(DRUID)){
+    if (sourceName.equals(DRUID)) {
       String startTime = getDruidTimeStamp((long)Math.ceil(start.getMillis()));
       String endTime = getDruidTimeStamp((long)Math.ceil(endExclusive.getMillis()));
       return String.format("%s BETWEEN '%s' AND '%s'", getToUnixTimeClause(timeFormat, timeField, sourceName), startTime, endTime);


### PR DESCRIPTION
## Description
We are seeing a bunch of performance issues on druid coz of the `TIME_EXTRACT` function. Looks like this isn't using the default druid segments optimized and created specifically on druid. Details about the findings are available [here](https://docs.google.com/document/d/1-5BqOMkBswyOh6E8SEjFFR5kqDqMepq030Bb1vYLRSU/edit#heading=h.h57tkb9m9vzk).

In essence, the current DRUID query looks like the following:
```
SELECT auth_type, avg(sr) FROM thirdeye_sr_fact WHERE TIME_EXTRACT("__time", 'EPOCH') BETWEEN 123456' and 78912' GROUP BY auth_type ORDER BY avg(sr) DESC
```
Modify the above with something like the following:
```
SELECT auth_type, avg(sr) FROM thirdeye_sr_fact WHERE __time BETWEEN '2020-10-20' and '2020-10-21' GROUP BY auth_type ORDER BY avg(sr) DESC
```
## Upgrade Notes
No Specific upgrades noted here.

## Does this PR fix a zero-downtime upgrade introduced earlier?
Nothing explicit

## Notes to reviewer:
1. The default query is done at a per second interval. In the sense, the time periods will look like '2020-09-01 11:20:30.000' and not '2020-09-01'.
2. We still use `BETWEEN` clause instead of `>=`. Is this going to be an issue? 
3. We are explicitly setting the timezone to `Asia/Calcutta` specific to the IST use case we have. 

## Release Notes
Nothing significant except for potential performance improvements

## Documentation
No new feature