### PR TITLE
Slack integration

### DIFF
--- a/thirdeye/thirdeye-dashboard/config/detector.yml
+++ b/thirdeye/thirdeye-dashboard/config/detector.yml
@@ -30,8 +30,8 @@ alerterConfiguration:
     smtpHost: "localhost"
     smtpPort: 25
   slackConfiguration:
-    webhookUrl: "https://hooks.slack.com/services/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"
-    defaultChannel: "#test_java_alerts_obsv"
+    webhookUrl: "replaceme"
+    defaultChannel: "replaceme"
   # slackUser: <REPLACE_ME>
 
 #  jiraConfiguration:

--- a/thirdeye/thirdeye-dashboard/config/detector.yml
+++ b/thirdeye/thirdeye-dashboard/config/detector.yml
@@ -13,22 +13,27 @@ server:
       port: 1868
   requestLog:
     type: external
-alert: false
-autoload: false
+alert: true
+autoload: true
 holidayEventsLoader: false
-mockEventsLoader: true
+mockEventsLoader: false
 monitor: false
 pinotProxy: false
-scheduler: false
-worker: false
-detectionPipeline: false
-detectionAlert: false
+scheduler: true
+worker: true
+detectionPipeline: true
+detectionAlert: true
 dashboardHost: "http://localhost:1426"
 id: 0
 alerterConfiguration:
   smtpConfiguration:
     smtpHost: "localhost"
     smtpPort: 25
+  slackConfiguration:
+    webhookUrl: "https://hooks.slack.com/services/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"
+    defaultChannel: "#test_java_alerts_obsv"
+  # slackUser: <REPLACE_ME>
+
 #  jiraConfiguration:
 #    jiraUser: <REPLACE_ME>
 #    jiraPassword: <REPLACE_ME>

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -338,6 +338,12 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
+    	<!-- https://mvnrepository.com/artifact/com.slack.api/slack-api-client -->
+		<dependency>
+			<groupId>com.slack.api</groupId>
+			<artifactId>slack-api-client</artifactId>
+			<version>1.2.1</version>
+		</dependency>
 
     <!-- yaml validator -->
     <dependency>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/utils/ThirdeyeMetricsUtil.java
@@ -197,6 +197,15 @@ public class ThirdeyeMetricsUtil {
   public static final Counter jiraAlertsNumCommentsCounter =
       metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "jiraAlertsNumCommentsCounter");
 
+  public static final Counter slackAlertsSuccessCounter =
+    metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "slackAlertsSuccessCounter");
+
+  public static final Counter slackAlertsFailedCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "slackAlertsFailedCounter");
+
+  public static final Counter slackAlertsNumMessageCounter =
+      metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "slackAlertsNumMessageCounter");
+
   public static final Counter onlineTaskCounter =
           metricsRegistry.newCounter(ThirdeyeMetricsUtil.class, "onlineTaskCounter");
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionSlackAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/alert/scheme/DetectionSlackAlerter.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.detection.alert.scheme;
+
+import static org.apache.pinot.thirdeye.notification.commons.SlackConfiguration.SLACK_CONF;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
+import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyResult;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import org.apache.pinot.thirdeye.detection.ConfigUtils;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterNotification;
+import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilterResult;
+import org.apache.pinot.thirdeye.detection.annotation.AlertScheme;
+import org.apache.pinot.thirdeye.notification.commons.SlackConfiguration;
+import org.apache.pinot.thirdeye.notification.commons.SlackEntity;
+import org.apache.pinot.thirdeye.notification.commons.ThirdEyeSlackClient;
+import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.notification.formatter.channels.SlackContentFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible for creating the slack alert tickets
+ *
+ * detector.yml alertSchemes: - type: SLACK params: webhookUrl:
+ * https://hooks.slack.com/services/XYZ/LMNOP/ABCD
+ */
+@AlertScheme(type = "SLACK")
+public class DetectionSlackAlerter extends DetectionAlertScheme {
+	private static final Logger LOG = LoggerFactory.getLogger(DetectionSlackAlerter.class);
+
+	private ThirdEyeAnomalyConfiguration teConfig;
+	private ThirdEyeSlackClient slackClient;
+	private SlackConfiguration slackAdminConfig;
+
+	public static final String PROP_SLACK_SCHEME = "slackScheme";
+	public static final int SLACK_DESCRIPTION_MAX_LENGTH = 100000;
+
+	public DetectionSlackAlerter(DetectionAlertConfigDTO subsConfig, ThirdEyeAnomalyConfiguration thirdeyeConfig,
+			DetectionAlertFilterResult result, ThirdEyeSlackClient slackClient) {
+		super(subsConfig, result);
+		this.teConfig = thirdeyeConfig;
+		this.slackAdminConfig = SlackConfiguration
+				.createFromProperties(this.teConfig.getAlerterConfiguration().get(SLACK_CONF));
+		this.slackClient = slackClient;
+	}
+
+	public DetectionSlackAlerter(DetectionAlertConfigDTO subsConfig, ThirdEyeAnomalyConfiguration thirdeyeConfig,
+			DetectionAlertFilterResult result) throws Exception {
+		this(subsConfig, thirdeyeConfig, result, new ThirdEyeSlackClient());
+	}
+
+	private SlackEntity buildSlackEntity(DetectionAlertFilterNotification notification,
+			Set<MergedAnomalyResultDTO> anomalies) {
+		DetectionAlertConfigDTO subsetSubsConfig = notification.getSubscriptionConfig();
+		if (subsetSubsConfig.getAlertSchemes().get(PROP_SLACK_SCHEME) == null) {
+			throw new IllegalArgumentException("Slack not configured in subscription group " + this.subsConfig.getId());
+		}
+
+		Properties slackClientConfig = new Properties();
+		slackClientConfig.putAll(ConfigUtils.getMap(subsetSubsConfig.getAlertSchemes().get(PROP_SLACK_SCHEME)));
+
+		List<AnomalyResult> anomalyResultListOfGroup = new ArrayList<>(anomalies);
+		anomalyResultListOfGroup.sort(COMPARATOR_DESC);
+
+		BaseNotificationContent content = getNotificationContent(slackClientConfig);
+
+		return new SlackContentFormatter(this.slackAdminConfig, slackClientConfig, content, this.teConfig,
+				subsetSubsConfig).getSlackEntity(notification.getDimensionFilters(), anomalyResultListOfGroup);
+	}
+
+	private void createSlackMsgs(DetectionAlertFilterResult results) throws Exception {
+		LOG.info("Preparing a slack alert for subscription group id {}", this.subsConfig.getId());
+		Preconditions.checkNotNull(results.getResult());
+		for (Map.Entry<DetectionAlertFilterNotification, Set<MergedAnomalyResultDTO>> result : results.getResult()
+				.entrySet()) {
+			try {
+				SlackEntity slackEntity = buildSlackEntity(result.getKey(), result.getValue());
+				String response = slackClient.createMessage(slackEntity);
+				if (response != null && response.equals("200")) {
+					LOG.error("Slack alert failed for {} anomalies", result.getValue().size());
+					ThirdeyeMetricsUtil.slackAlertsFailedCounter.inc();
+				} else {
+					ThirdeyeMetricsUtil.slackAlertsSuccessCounter.inc();
+					ThirdeyeMetricsUtil.slackAlertsNumMessageCounter.inc();
+					LOG.info("Slack alert created for {} anomalies", result.getValue().size());
+				}
+
+			} catch (Exception e) {
+				ThirdeyeMetricsUtil.slackAlertsFailedCounter.inc();
+				super.handleAlertFailure(result.getValue().size(), e);
+			}
+		}
+	}
+
+	@Override
+	public void run() throws Exception {
+		Preconditions.checkNotNull(result);
+		if (result.getAllAnomalies().isEmpty()) {
+			LOG.info("Zero anomalies found, skipping creation of slack alert for {}", this.subsConfig.getId());
+			return;
+		}
+
+		createSlackMsgs(result);
+	}
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/SlackConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/SlackConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.notification.commons;
+
+import java.util.Map;
+
+import com.google.common.base.MoreObjects;
+
+import org.apache.commons.collections4.MapUtils;
+
+public class SlackConfiguration {
+
+	public static final String SLACK_CONF = "slackConfiguration";
+	public static final String SLACK_URL = "webhookUrl";
+
+	private String url;
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this).add(SLACK_URL, url).toString();
+	}
+
+	public static SlackConfiguration createFromProperties(Map<String, Object> slackConfiguration) {
+		SlackConfiguration conf = new SlackConfiguration();
+		try {
+			conf.setUrl(MapUtils.getString(slackConfiguration, SLACK_URL));
+		} catch (Exception e) {
+			throw new RuntimeException("Error occurred while parsing slack configuration into object.", e);
+		}
+		return conf;
+	}
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/SlackEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/SlackEntity.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.notification.commons;
+
+import java.util.Map;
+
+/**
+ * ThirdEye's Slack Settings Holder
+ */
+public class SlackEntity {
+	private String url;
+	private String summary;
+	private String description;
+	// Place holder for configuring non-standard customized slack fields
+	private Map<String, Object> customFieldsMap;
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getSummary() {
+		return summary;
+	}
+
+	public void setSummary(String summary) {
+		this.summary = summary;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Map<String, Object> getCustomFieldsMap() {
+		return customFieldsMap;
+	}
+
+	public void setCustomFieldsMap(Map<String, Object> customFieldsMap) {
+		this.customFieldsMap = customFieldsMap;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("Slack{");
+		sb.append("slackUrl='").append(url).append('\'');
+		sb.append(", summary='").append(summary).append('\'');
+		sb.append(", custom='").append(customFieldsMap).append('\'');
+		sb.append('}');
+		return sb.toString();
+	}
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeSlackClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeSlackClient.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.notification.commons;
+
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.slack.api.Slack;
+import com.slack.api.model.block.DividerBlock;
+import com.slack.api.model.block.HeaderBlock;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.SectionBlock;
+import com.slack.api.model.block.composition.MarkdownTextObject;
+import com.slack.api.webhook.WebhookResponse;
+
+/**
+ * A client to communicate with Slack
+ */
+public class ThirdEyeSlackClient {
+	private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeSlackClient.class);
+	private Slack slack;
+
+	public ThirdEyeSlackClient() {
+		this.slack = Slack.getInstance();
+	}
+
+	/**
+	 * Creates a new slack message with specified settings
+	 */
+	public String createMessage(SlackEntity slackEntity) {
+		String webhookUrl = slackEntity.getUrl();
+		List<LayoutBlock> message = new ArrayList<>();
+		message.add(HeaderBlock.builder().text(plainText("New Anamoly Alert")).build());
+		message.add(DividerBlock.builder().build());
+
+		message.add(SectionBlock.builder().text(MarkdownTextObject.builder().text(slackEntity.getSummary()).build())
+				.build());
+		message.add(SectionBlock.builder().text(MarkdownTextObject.builder().text(slackEntity.getDescription()).build())
+				.build());
+		WebhookResponse response = null;
+		try {
+			response = slack.send(webhookUrl, payload(p -> p.blocks(message)));
+		} catch (IOException e) {
+			LOG.error(Arrays.toString(e.getStackTrace()));
+		}
+		if (response != null) {
+			return response.getCode().toString();
+		}
+		return null;
+	}
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/formatter/channels/SlackContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/formatter/channels/SlackContentFormatter.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.thirdeye.notification.formatter.channels;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Multimap;
+
+import org.apache.commons.collections4.MapUtils;
+import org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import org.apache.pinot.thirdeye.anomalydetection.context.AnomalyResult;
+import org.apache.pinot.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import org.apache.pinot.thirdeye.notification.commons.SlackConfiguration;
+import org.apache.pinot.thirdeye.notification.commons.SlackEntity;
+import org.apache.pinot.thirdeye.notification.content.BaseNotificationContent;
+import org.apache.pinot.thirdeye.notification.content.templates.MetricAnomaliesContent;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateExceptionHandler;
+
+/**
+ * This class formats the content for slack alerts
+ */
+public class SlackContentFormatter extends AlertContentFormatter {
+
+	private SlackConfiguration slackAdminConfig;
+
+	private static final String CHARSET = "UTF-8";
+
+	private static final Map<String, String> alertContentToTemplateMap;
+
+	static {
+		Map<String, String> aMap = new HashMap<>();
+		aMap.put(MetricAnomaliesContent.class.getSimpleName(), "slack-metric-anomalies-template.ftl");
+		alertContentToTemplateMap = Collections.unmodifiableMap(aMap);
+	}
+
+	public SlackContentFormatter(SlackConfiguration slackAdminConfig, Properties slackClientConfig,
+			BaseNotificationContent content, ThirdEyeAnomalyConfiguration teConfig,
+			DetectionAlertConfigDTO subsConfig) {
+		super(slackClientConfig, content, teConfig, subsConfig);
+
+		this.slackAdminConfig = slackAdminConfig;
+		validateSlackConfigs(slackAdminConfig);
+	}
+
+	/**
+	 * Make sure the base admin parameters are configured before proceeding
+	 */
+	private void validateSlackConfigs(SlackConfiguration slackAdminConfig) {
+		Preconditions.checkNotNull(slackAdminConfig.getUrl());
+	}
+
+	/**
+	 * Format and construct a {@link SlackEntity} by rendering the anomalies and
+	 * properties
+	 *
+	 * @param dimensionFilters dimensions configured in the multi-dimensions alerter
+	 * @param anomalies        anomalies to be reported to recipients configured in
+	 *                         (@link #slackClientConfig}
+	 */
+	public SlackEntity getSlackEntity(Multimap<String, String> dimensionFilters, Collection<AnomalyResult> anomalies) {
+		Map<String, Object> templateData = notificationContent.format(anomalies, this.subsConfig);
+		templateData.put("dashboardHost", teConfig.getDashboardHost());
+		return buildSlackEntity(alertContentToTemplateMap.get(notificationContent.getTemplate()), templateData,
+				dimensionFilters);
+	}
+
+	private String buildSummary(Map<String, Object> templateValues, Multimap<String, String> dimensionFilters) {
+		String issueSummary = BaseNotificationContent.makeSubject(super.getSubjectType(alertClientConfig),
+				this.subsConfig, templateValues);
+
+		// Append dimensional info to summary
+		StringBuilder dimensions = new StringBuilder();
+		for (Map.Entry<String, Collection<String>> dimFilter : dimensionFilters.asMap().entrySet()) {
+			dimensions.append(", ").append(dimFilter.getKey()).append("=")
+					.append(String.join(",", dimFilter.getValue()));
+		}
+		issueSummary = issueSummary + dimensions.toString();
+		return issueSummary;
+	}
+
+	private String buildDescription(String slackTemplate, Map<String, Object> templateValues) {
+		String description;
+
+		// Render the values in templateValues map to the slack ftl template file
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (Writer out = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
+			Configuration freemarkerConfig = new Configuration(Configuration.VERSION_2_3_21);
+			freemarkerConfig.setClassForTemplateLoading(getClass(), "/org/apache/pinot/thirdeye/detector");
+			freemarkerConfig.setDefaultEncoding(CHARSET);
+			freemarkerConfig.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+			Template template = freemarkerConfig.getTemplate(slackTemplate);
+			template.process(templateValues, out);
+
+			description = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+		} catch (Exception e) {
+			description = "Found an exception while constructing the description content. Pls report & reach out"
+					+ " to the Thirdeye team. Exception = " + e.getMessage();
+		}
+
+		return description;
+	}
+
+	/**
+	 * Apply the parameter map to given slack template, and format it as SlackEntity
+	 */
+	private SlackEntity buildSlackEntity(String slackTemplate, Map<String, Object> templateValues,
+			Multimap<String, String> dimensionFilters) {
+		String webhookUrl = MapUtils.getString(alertClientConfig, SlackConfiguration.SLACK_URL,
+				this.slackAdminConfig.getUrl());
+		SlackEntity slackEntity = new SlackEntity();
+		slackEntity.setUrl(webhookUrl);
+		slackEntity.setDescription(buildDescription(slackTemplate, templateValues));
+		slackEntity.setSummary(buildSummary(templateValues, dimensionFilters));
+		return slackEntity;
+	}
+}

--- a/thirdeye/thirdeye-pinot/src/main/resources/org/apache/pinot/thirdeye/detector/slack-metric-anomalies-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/org/apache/pinot/thirdeye/detector/slack-metric-anomalies-template.ftl
@@ -1,0 +1,40 @@
+<#if anomalyCount == 1>
+  ThirdEye has detected <${dashboardHost}/app/#/anomalies?anomalyIds=${anomalyIds}|an anomaly> on the metric <#list metricsMap?keys as id>*${metricsMap[id].name}*</#list> between *${startTime}* and *${endTime}* (${timeZone})
+<#else>
+  ThirdEye has detected <${dashboardHost}/app/#/anomalies?anomalyIds=${anomalyIds}|${anomalyCount} anomalies> on the metrics listed below between *${startTime}* and *${endTime}* (${timeZone})
+</#if>
+<#list metricToAnomalyDetailsMap?keys as metric>
+  <#list detectionToAnomalyDetailsMap?keys as detectionName>
+    <#assign newTable = false>
+    <#list detectionToAnomalyDetailsMap[detectionName] as anomaly>
+      <#if anomaly.metric==metric>
+        <#assign newTable=true>
+        <#assign description=anomaly.funcDescription>
+      </#if>
+    </#list>
+
+    <#if newTable>
+      *Metric:* _${metric}_
+      *Alert Name:* <${dashboardHost}/app/#/manage/explore/${functionToId[detectionName]?string.computer}| _${detectionName}_ >
+      *Description:* ${description}
+    </#if>
+
+    <#list detectionToAnomalyDetailsMap[detectionName] as anomaly>
+      <#if anomaly.metric==metric>
+        <#if newTable>
+          Start: ${anomaly.startDateTime} ${anomaly.timezone}
+          Link: ${anomaly.anomalyURL}${anomaly.anomalyId}
+          Duration: ${anomaly.duration}
+          Type: ${anomaly.anomalyType}
+          Dimensions: <#if anomaly.dimensions?has_content><#list anomaly.dimensions as dimension> _${dimension}_ </#list><#else> _none_ </#if>
+          Current:  _${anomaly.currentVal}_
+          Predicted: ${anomaly.baselineVal}
+          Change: ${anomaly.positiveLift?string('+','')}${anomaly.lift}
+        </#if>
+        <#assign newTable = false>
+      </#if>
+    </#list>
+  </#list>
+</#list>
+
+_You are receiving this alert because you have subscribed to ThirdEye Alert Service for *${alertConfigName}*. If you have any questions regarding this report, please contact thirdeye team_


### PR DESCRIPTION
## Description
Slack notification support for anamalies. Implementation is in line with existing notification support code. (JIRA & Email)

## Upgrade Notes
Not Applicable

## Release Notes
- New configuration options : Slack Notifications for anamalies
- New configuration options : add `slackConfiguration` in `config/detector.yml` valid parameters are `webhookUrl` and `defaultChannel`