### PR TITLE
Update RootCauseResource for swagger

### DIFF
--- a/thirdeye/thirdeye-dashboard/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseResource.java
+++ b/thirdeye/thirdeye-dashboard/src/main/java/org/apache/pinot/thirdeye/dashboard/resources/v2/RootCauseResource.java
@@ -114,13 +114,13 @@ public class RootCauseResource {
       @QueryParam("analysisStart") Long analysisStart,
       @ApiParam(value = "end of overall time window to consider for events")
       @QueryParam("analysisEnd") Long analysisEnd,
-      @ApiParam(value = "start time of the anomalous time period for the metric under analysis", defaultValue = "analysisStart")
+      @ApiParam(value = "start time of the anomalous time period for the metric under analysis", defaultValue = "7")
       @QueryParam("anomalyStart") Long anomalyStart,
-      @ApiParam(value = "end time of the anomalous time period for the metric under analysis", defaultValue = "analysisEnd")
+      @ApiParam(value = "end time of the anomalous time period for the metric under analysis", defaultValue = "7")
       @QueryParam("anomalyEnd") Long anomalyEnd,
-      @ApiParam(value = "baseline start time, e.g. anomaly start time offset by 1 week", defaultValue = "anomalyStart - 7 days")
+      @ApiParam(value = "baseline start time, e.g. anomaly start time offset by 1 week", defaultValue = "7")
       @QueryParam("baselineStart") Long baselineStart,
-      @ApiParam(value = "baseline end time, e.g. typically anomaly start time offset by 1 week", defaultValue = "anomalyEnd - 7 days")
+      @ApiParam(value = "baseline end time, e.g. typically anomaly start time offset by 1 week", defaultValue = "7")
       @QueryParam("baselineEnd") Long baselineEnd,
       @QueryParam("formatterDepth") Integer formatterDepth,
       @ApiParam(value = "URNs of metrics to analyze")


### PR DESCRIPTION
fix defaultValues for analysis start and end time. String to Long
fix defaultValues for baseline anomaly start time and end time. String to Long

Fixes below issues.

Steps to reproduce

1. execute - `./run-frontend.sh`
2. open `http://<host:port>/swagger`

![image](https://user-images.githubusercontent.com/54934534/99478427-61e3cc80-297a-11eb-9918-c09de5012847.png)
![image](https://user-images.githubusercontent.com/54934534/99478599-ad967600-297a-11eb-9594-551dc375ac62.png)
![image](https://user-images.githubusercontent.com/54934534/99478616-b8e9a180-297a-11eb-85bc-9a4947120f3c.png)
