### PR TITLE
[thirdeye:timescaledb] - Adds prod timescaledb endpoint as a data source

### DIFF
--- a/thirdeye/thirdeye-dashboard/config/data-sources/data-sources-config.yml
+++ b/thirdeye/thirdeye-dashboard/config/data-sources/data-sources-config.yml
@@ -10,11 +10,11 @@ dataSourceConfigs:
           password: ?$MYSQL_PASSWORD
           driver: com.mysql.cj.jdbc.Driver
       # PostgreSQL is for local deployment
-      # PostgreSQL:
-      #   - db:
-      #       postgres: jdbc:postgresql://?$POSTGRES_HOSTNAME:?$POSTGRES_PORT/?$THIRDEYE_POSTGRES_DATABASE
-      #     user: ?$THIRDEYE_POSTGRES_USER
-      #     password: ?$THIRDEYE_POSTGRES_PASSWORD
+      PostgreSQL:
+        - db:
+            postgres: jdbc:postgresql://timescaledb-de.razorpay.com:9090/realtime
+          user: thirdeye
+          password: ?$TIMESCALEDB_PASSWORD
       Druid:
         - db:
             druid: jdbc:avatica:remote:url=?$DRUID_URL

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlResponseCacheLoader.java
@@ -221,6 +221,12 @@ public class SqlResponseCacheLoader extends CacheLoader<SqlQuery, ThirdEyeResult
 					dataSource.setRemoveAbandonedTimeout(ABANDONED_TIMEOUT);
 					dataSource.setRemoveAbandoned(true);
 
+					//From StackOverflow: https://stackoverflow.com/questions/29620265/postgres-connection-has-been-closed-error-in-spring-boot
+					dataSource.setTestOnBorrow(true);
+					dataSource.setTestWhileIdle(true);
+					dataSource.setTestOnReturn(true);
+					dataSource.setValidationQuery("SELECT 1");
+
 					postgresqlDBNameToDataSourceMap.put(entry.getKey(), dataSource);
 					postgresqlDBNameToURLMap.putAll(dbNameToURLMap);
 				}

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/sql/SqlUtils.java
@@ -694,7 +694,8 @@ public class SqlUtils {
     } else if (sourceName.equals(MYSQL)) {
       return "UNIX_TIMESTAMP(STR_TO_DATE(CAST(" + timeColumn + " AS CHAR), '" + timeFormatToMySQLFormat(timeFormat) + "'))";
     } else if (sourceName.equals(POSTGRESQL)) {
-      return "EXTRACT(EPOCH FROM to_timestamp(" + timeColumn + ", '" + timeFormatToPostgreSQLFormat(timeFormat) + "'))";
+      return timeColumn;
+      //return "EXTRACT(EPOCH FROM to_timestamp(" + timeColumn + ", '" + timeFormatToPostgreSQLFormat(timeFormat) + "'))";
     } else if (sourceName.equals(DRUID)) {
       //return "TIME_EXTRACT(" + timeColumn + ", '" + timeFormatToDruidFormat(timeFormat) + "') ";
       return timeColumn;


### PR DESCRIPTION
## Description
Adds timescaledb as a source
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
